### PR TITLE
include cod in pdf invoice

### DIFF
--- a/Model/Sales/Pdf/Amount.php
+++ b/Model/Sales/Pdf/Amount.php
@@ -22,23 +22,13 @@ namespace MSP\CashOnDelivery\Model\Sales\Pdf;
 
 class Amount extends \Magento\Sales\Model\Order\Pdf\Total\DefaultTotal
 {
-    public function getTotalsForDisplay()
+    /**
+     * Get Total amount from source
+     *
+     * @return float
+     */
+    public function getAmount()
     {
-        $order = $this->getOrder();
-        $amount = $order->formatPriceTxt($order->getMspCodAmount());
-        if ($this->getAmountPrefix()) {
-            $amount = $this->getAmountPrefix() . $amount;
-        }
-
-        $title = __($this->getTitle());
-        if ($this->getTitleSourceField()) {
-            $label = $title . ' (' . $this->getTitleDescription() . '):';
-        } else {
-            $label = $title . ':';
-        }
-
-        $fontSize = $this->getFontSize() ? $this->getFontSize() : 7;
-        $total = ['amount' => $amount, 'label' => $label, 'font_size' => $fontSize];
-        return [$total];
+        return $this->getOrder()->getMspCodAmount();
     }
 }

--- a/Model/Sales/Pdf/Amount.php
+++ b/Model/Sales/Pdf/Amount.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * IDEALIAGroup srl
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to info@idealiagroup.com so we can send you a copy immediately.
+ *
+ * @category   MSP
+ * @package    MSP_CashOnDelivery
+ * @copyright  Copyright (c) 2016 IDEALIAGroup srl (http://www.idealiagroup.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace MSP\CashOnDelivery\Model\Sales\Pdf;
+
+class Amount extends \Magento\Sales\Model\Order\Pdf\Total\DefaultTotal
+{
+    public function getTotalsForDisplay()
+    {
+        $order = $this->getOrder();
+        $amount = $order->formatPriceTxt($order->getMspCodAmount());
+        if ($this->getAmountPrefix()) {
+            $amount = $this->getAmountPrefix() . $amount;
+        }
+
+        $title = __($this->getTitle());
+        if ($this->getTitleSourceField()) {
+            $label = $title . ' (' . $this->getTitleDescription() . '):';
+        } else {
+            $label = $title . ':';
+        }
+
+        $fontSize = $this->getFontSize() ? $this->getFontSize() : 7;
+        $total = ['amount' => $amount, 'label' => $label, 'font_size' => $fontSize];
+        return [$total];
+    }
+}

--- a/Model/Sales/Pdf/Tax.php
+++ b/Model/Sales/Pdf/Tax.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * IDEALIAGroup srl
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to info@idealiagroup.com so we can send you a copy immediately.
+ *
+ * @category   MSP
+ * @package    MSP_CashOnDelivery
+ * @copyright  Copyright (c) 2016 IDEALIAGroup srl (http://www.idealiagroup.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace MSP\CashOnDelivery\Model\Sales\Pdf;
+
+class Tax extends \Magento\Sales\Model\Order\Pdf\Total\DefaultTotal
+{
+    public function getTotalsForDisplay()
+    {
+        $order = $this->getOrder();
+        $amount = $order->formatPriceTxt($order->getBaseMspCodTaxAmount());
+        if ($this->getAmountPrefix()) {
+            $amount = $this->getAmountPrefix() . $amount;
+        }
+
+        $title = __($this->getTitle());
+        if ($this->getTitleSourceField()) {
+            $label = $title . ' (' . $this->getTitleDescription() . '):';
+        } else {
+            $label = $title . ':';
+        }
+
+        $fontSize = $this->getFontSize() ? $this->getFontSize() : 7;
+        $total = ['amount' => $amount, 'label' => $label, 'font_size' => $fontSize];
+        return [$total];
+    }
+}

--- a/Model/Sales/Pdf/Tax.php
+++ b/Model/Sales/Pdf/Tax.php
@@ -22,23 +22,13 @@ namespace MSP\CashOnDelivery\Model\Sales\Pdf;
 
 class Tax extends \Magento\Sales\Model\Order\Pdf\Total\DefaultTotal
 {
-    public function getTotalsForDisplay()
+    /**
+     * Get Total amount from source
+     *
+     * @return float
+     */
+    public function getAmount()
     {
-        $order = $this->getOrder();
-        $amount = $order->formatPriceTxt($order->getBaseMspCodTaxAmount());
-        if ($this->getAmountPrefix()) {
-            $amount = $this->getAmountPrefix() . $amount;
-        }
-
-        $title = __($this->getTitle());
-        if ($this->getTitleSourceField()) {
-            $label = $title . ' (' . $this->getTitleDescription() . '):';
-        } else {
-            $label = $title . ':';
-        }
-
-        $fontSize = $this->getFontSize() ? $this->getFontSize() : 7;
-        $total = ['amount' => $amount, 'label' => $label, 'font_size' => $fontSize];
-        return [$total];
+        return $this->getOrder()->getBaseMspCodTaxAmount();
     }
 }

--- a/etc/pdf.xml
+++ b/etc/pdf.xml
@@ -23,6 +23,7 @@
     <totals>
         <total name="msp_cashondelivery">
             <title translate="true">Cash on delivery amount</title>
+            <source_field>msp_cashondelivery</source_field>
             <model>MSP\CashOnDelivery\Model\Sales\Pdf\Amount</model>
             <font_size>7</font_size>
             <display_zero>false</display_zero>
@@ -30,6 +31,7 @@
         </total>
         <total name="msp_cashondelivery_tax">
             <title translate="true">Cash on delivery tax</title>
+            <source_field>msp_cashondelivery_tax</source_field>
             <model>MSP\CashOnDelivery\Model\Sales\Pdf\Tax</model>
             <font_size>7</font_size>
             <display_zero>false</display_zero>

--- a/etc/pdf.xml
+++ b/etc/pdf.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * IDEALIAGroup srl
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to info@idealiagroup.com so we can send you a copy immediately.
+ *
+ * @category   MSP
+ * @package    MSP_CashOnDelivery
+ * @copyright  Copyright (c) 2016 IDEALIAGroup srl (http://www.idealiagroup.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Sales:etc/pdf_file.xsd">
+    <totals>
+        <total name="msp_cashondelivery">
+            <title translate="true">Cash on delivery amount</title>
+            <model>MSP\CashOnDelivery\Model\Sales\Pdf\Amount</model>
+            <font_size>7</font_size>
+            <display_zero>false</display_zero>
+            <sort_order>150</sort_order>
+        </total>
+        <total name="msp_cashondelivery_tax">
+            <title translate="true">Cash on delivery tax</title>
+            <model>MSP\CashOnDelivery\Model\Sales\Pdf\Tax</model>
+            <font_size>7</font_size>
+            <display_zero>false</display_zero>
+            <sort_order>151</sort_order>
+        </total>
+    </totals>
+</config>


### PR DESCRIPTION
this should include the fee in the PDF invoice, i copied the code over in a hurry and as long as i did not mess up the namespace and or paths it should work. best regards

taken from:
http://webkul.com/blog/add-custom-fee-downloaded-pdf-order-magento2/